### PR TITLE
Modifying diskusage_report to add the info from `duc`

### DIFF
--- a/bin/computecanada/diskusage_breakdown
+++ b/bin/computecanada/diskusage_breakdown
@@ -1,0 +1,7 @@
+#!/bin/bash
+cmd=$1
+fs=$(echo $cmd | awk -F "/" '{print $2}')
+p=$(echo $cmd | awk -F "/" '{print $3}')
+db="/${fs}/.duc_databases/${p}.sqlite"
+
+duc ui --database=/${db} $cmd

--- a/bin/computecanada/diskusage_report
+++ b/bin/computecanada/diskusage_report
@@ -195,3 +195,27 @@ fi
 #		find_and_report_usage $p /nearline
 #	done
 #fi
+
+declare -a breakdowns
+for fs in project nearline; do
+	db="/${fs}/.duc_databases/${p}.sqlite"
+	for p in $(get_projects "projects"); do
+		if [[ -f "$db" ]]; then
+			breakdowns+=("diskusage_breakdown /${fs}/${p} \t (Last update: $(stat --format "%y" $db | awk -F '.' '{print $1}'))")
+		fi
+	done
+done
+
+for fs in home scratch; do
+	if [[ -f "/${fs}/.duc_databases/${USER}.sqlite" ]]; then
+		breakdowns+=("diskusage_breakdown /${fs}/${USER} \t (Last update: $(stat --format "%y" /${fs}/.duc_databases/${USER}.sqlite | awk -F '.' '{print $1}'))")
+	fi
+done
+
+if (( ${#breakdowns[@]} )); then
+	printf "\nDetailed breakdowns are available with the following commands:\n"
+	for value in "${breakdowns[@]}"
+	do
+		printf "$value\n"
+	done
+fi


### PR DESCRIPTION
This add a section in the bottom of `diskusage_report` that is only displayed if the databases exist on disk.  