### PR TITLE
Mods for Siku

### DIFF
--- a/bin/computecanada/diskusage_report
+++ b/bin/computecanada/diskusage_report
@@ -105,7 +105,7 @@ function get_quota_info_from_files {
 	if [[ -f $quota_file ]]; then
 		# returns 9 values. time, space usage, space soft quota, space hard quota,
 		#   space in doubt, grace period, file usage, file soft quota, file hard quota
-		tail -1 $quota_file | awk '{print $1,$4,$5,$6,$7,$8,$10,$11,$12}' | sed -e 's/\*//g'
+		tail -1 $quota_file | sed 's/ \(days\|hours\?\)/_\1/g' | awk '{print $1,$4,$5,$6,$7,$8,$10,$11,$12}' | sed -e 's/\*//g'
 	else
 		echo "QUOTA_FILE_NOT_FOUND"
 	fi

--- a/bin/computecanada/diskusage_report
+++ b/bin/computecanada/diskusage_report
@@ -52,7 +52,7 @@ done
 
 
 REPORT_USER_QUOTA_ON_PROJECT=0
-if [[ "$CC_CLUSTER" == "cedar" || "$CC_CLUSTER" == "graham" || "$CC_CLUSTER" == "beluga" ]]; then
+if [[ "$CC_CLUSTER" == "cedar" || "$CC_CLUSTER" == "graham" || "$CC_CLUSTER" == "beluga" || "$CC_CLUSTER" == "siku" ]]; then
 	REPORT_USER_QUOTA_ON_PROJECT=1
 fi
 QUOTA_IN_FILES=0


### PR DESCRIPTION
Siku uses GPFS for shared FS, which doesn't allow users to query their quota like `lfs quota` does.
Instead a cron-job dumps the quota information into files, which are then used by `diskusage_report` to read the data.

This PR fixes two issues:

1) When a quota is exceeded, the column that contains the remaining "grace period" will change from `none` to `7 days`, `36 hours`, `1 hour` and finally to `expired`.  The extra space-char causes the parsing of the file to fail, resulting in an error message during the grace period.
  The fix is to include a `sed` into the pipe that replaces that space with an underscore ahead of `(days|hours?)`.

2) The reporting of user-quota on /project is now enabled on Siku.