### PR TITLE
Load default versions of modules in StdEnv/2020

### DIFF
--- a/modules/StdEnv/2020.lua
+++ b/modules/StdEnv/2020.lua
@@ -17,6 +17,6 @@ if (mode() == "spider") then
 	end
 end
 
-load("imkl/2020.1.217")
-load("intel/2020.1.217")
-load("openmpi/4.0.3")
+load("imkl")
+load("intel")
+load("openmpi")


### PR DESCRIPTION
This way it's possible to do "module load intel/2021.2.0" and have
it autoload openmpi/4.1.1 instead of saying

Inactive Modules:
  1) openmpi/4.0.3

The defaults are set in the module directories using .modulerc.lua
files and unchanged from what is in StdEnv/2020.lua before this
change (e.g. version 2020.1.217 for intel/imkl)