### PR TITLE
Revert "added code to set SINGULARITY_CACHEDIR"

### DIFF
--- a/modules/singularity/3.5.lua
+++ b/modules/singularity/3.5.lua
@@ -22,20 +22,3 @@ else
 	setenv("SINGULARITY_TMPDIR",scratch)
 end
 
-local posix = require "posix"
-local user = os.getenv("USER") or nil
-if user then
-	local home = os.getenv("HOME") or pathJoin("/home", user)
-	local default_singularity_cachedir = pathJoin(home, ".singularity")
-	local default_singularity_cachedir_type = posix.stat(default_singularity_cachedir, "type") or nil
-	if default_singularity_cachedir_type == "directory" or default_singularity_cachedir_type == "link"  then
-		setenv("SINGULARITY_CACHEDIR", default_singularity_cachedir)
-	else
-		local singularity_cachedir = pathJoin(scratch, ".singularity")
-		local singularity_cachedir_type = posix.stat(singularity_cachedir, "type") or nil
-		if singularity_cachedir_type == "directory" or singularity_cachedir_type == "link" then
-			setenv("SINGULARITY_CACHEDIR", singularity_cachedir)
-		end
-	end
-end
-

--- a/modules/singularity/3.6.lua
+++ b/modules/singularity/3.6.lua
@@ -22,20 +22,3 @@ else
 	setenv("SINGULARITY_TMPDIR",scratch)
 end
 
-local posix = require "posix"
-local user = os.getenv("USER") or nil
-if user then
-	local home = os.getenv("HOME") or pathJoin("/home", user)
-	local default_singularity_cachedir = pathJoin(home, ".singularity")
-	local default_singularity_cachedir_type = posix.stat(default_singularity_cachedir, "type") or nil
-	if default_singularity_cachedir_type == "directory" or default_singularity_cachedir_type == "link"  then
-		setenv("SINGULARITY_CACHEDIR", default_singularity_cachedir)
-	else
-		local singularity_cachedir = pathJoin(scratch, ".singularity")
-		local singularity_cachedir_type = posix.stat(singularity_cachedir, "type") or nil
-		if singularity_cachedir_type == "directory" or singularity_cachedir_type == "link" then
-			setenv("SINGULARITY_CACHEDIR", singularity_cachedir)
-		end
-	end
-end
-

--- a/modules/singularity/3.7.lua
+++ b/modules/singularity/3.7.lua
@@ -22,20 +22,3 @@ else
 	setenv("SINGULARITY_TMPDIR",scratch)
 end
 
-local posix = require "posix"
-local user = os.getenv("USER") or nil
-if user then
-	local home = os.getenv("HOME") or pathJoin("/home", user)
-	local default_singularity_cachedir = pathJoin(home, ".singularity")
-	local default_singularity_cachedir_type = posix.stat(default_singularity_cachedir, "type") or nil
-	if default_singularity_cachedir_type == "directory" or default_singularity_cachedir_type == "link"  then
-		setenv("SINGULARITY_CACHEDIR", default_singularity_cachedir)
-	else
-		local singularity_cachedir = pathJoin(scratch, ".singularity")
-		local singularity_cachedir_type = posix.stat(singularity_cachedir, "type") or nil
-		if singularity_cachedir_type == "directory" or singularity_cachedir_type == "link" then
-			setenv("SINGULARITY_CACHEDIR", singularity_cachedir)
-		end
-	end
-end
-


### PR DESCRIPTION
Reverts ComputeCanada/software-stack-custom#15

After testing, the above does not work. If the folder does not exist, singularity reverts back to $HOME/.singularity/cache. Setting SINGULARITY_CACHEDIR to $SCRATCH would create $SCRATCH/cache, which is a risk of conflict with users' files in $SCRATCH