### PR TITLE
Show error message for virtualenv with StdEnv/2020.

### DIFF
--- a/bin/virtualenv
+++ b/bin/virtualenv
@@ -1,6 +1,11 @@
 #!/bin/sh
 if [ -n "$EBROOTGENTOO" ]; then
-	exec /cvmfs/soft.computecanada.ca/gentoo/2019/usr/bin/virtualenv ${1+"$@"}
+	if [[ ${LANG:0:2} == fr ]]; then
+		echo "S.v.p. chargez un module pour Python avant de lancer virtualenv."
+	else
+		echo "Please load a Python module before running virtualenv."
+	fi
+else
+	module load python/2.7.14
+	exec virtualenv ${1+"$@"}
 fi
-module load python/2.7.14
-exec virtualenv ${1+"$@"}


### PR DESCRIPTION
It was loading the one from gentoo/2019, an old leftover from
when I compiled Python with Gentoo instead of EasyBuild.