### PR TITLE
added symlinks for scp and sftp to use the os-provided versions

### DIFF
--- a/bin/scp
+++ b/bin/scp
@@ -1,0 +1,1 @@
+/usr/bin/scp

--- a/bin/sftp
+++ b/bin/sftp
@@ -1,0 +1,1 @@
+/usr/bin/sftp


### PR DESCRIPTION
Can anyone think of a reason *not* to shadow the gentoo-provided scp/sftp to use the OS versions, just like we do for `ssh` ?