### PR TITLE
unset PAGER in gentoo as this is not needed and not POSIX

### DIFF
--- a/modules/gentoo/2020.lua.core
+++ b/modules/gentoo/2020.lua.core
@@ -28,7 +28,6 @@ elseif posix.stat("/etc/ssl/certs/","type") == "directory" then
 	setenv("CURL_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt")
 end
 
-pushenv("PAGER", "less -R")
 pushenv("LESSOPEN", "|lesspipe %s")
 if os.getenv("XDG_DATA_DIRS") then
 	prepend_path("XDG_DATA_DIRS", pathJoin(root, "usr/share"))


### PR DESCRIPTION
I believe this fixes https://github.com/ComputeCanada/software-stack/issues/92

Paul, can you test by manually unsetting `PAGER` in your use case ? 