### PR TITLE
On AMD systems load FlexiBLAS and BLIS.

### DIFF
--- a/modules/StdEnv/2020.lua
+++ b/modules/StdEnv/2020.lua
@@ -20,3 +20,8 @@ end
 load("imkl")
 load("intel")
 load("openmpi")
+if cpu_vendor_id == "amd" then
+	load("flexiblas")
+	load("blis")
+	setenv("FLEXIBLAS", "blis")
+end


### PR DESCRIPTION
BLIS performs better than MKL on those, and with FlexiBLAS
we can change dynamically for applications linked against it.