### PR TITLE
Add --no-mmap-output-file to ld.gold on Narval

### DIFF
--- a/bin/ld.gold
+++ b/bin/ld.gold
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [[ "$CC_CLUSTER" == "narval" ]]; then
+	# workaround for Lustre issue on Narval
+	exec ${EBROOTGENTOO-$NIXUSER_PROFILE}/bin/ld.gold --no-mmap-output-file ${1+"$@"}
+fi
+exec ${EBROOTGENTOO-$NIXUSER_PROFILE}/bin/ld.gold ${1+"$@"}

--- a/bin/ld.gold
+++ b/bin/ld.gold
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [[ "$CC_CLUSTER" == "narval" ]]; then
 	# workaround for Lustre issue on Narval
 	exec ${EBROOTGENTOO-$NIXUSER_PROFILE}/bin/ld.gold --no-mmap-output-file ${1+"$@"}


### PR DESCRIPTION
This option is necessary to workaround a Lustre bug visible only on Narval.
According to strace we see this:

mmap(NULL, 309576, PROT_READ|PROT_WRITE, MAP_SHARED, 18, 0) = 0x7f10e68b5000
--- SIGBUS {si_signo=SIGBUS, si_code=BUS_ADRERR, si_addr=0x7f10e68fbd88} ---

the address 0x7f10e68fbd88 is within the mmap'ed range 0x7f10e68b5000 to 0x7f10e68b5000+309576
so this should not SIGBUS

Since it will take some time to fix the bug on Lustre's end I feel the wrapper is
the best solution for the near future. There's a bug report with a very similar
error but that's supposed to be fixed so not sure what is happening here:
https://jira.whamcloud.com/browse/LU-13588