### PR TITLE
Add or=00 to LS_COLORS

### DIFF
--- a/modules/CCconfig.lua
+++ b/modules/CCconfig.lua
@@ -37,7 +37,7 @@ end
 if not os.getenv("RSNT_NO_LS_COLORS") then
 	-- do not colour certain attributes of ls
 	-- this avoids inode lookups for plain "ls"
-	append_path("LS_COLORS", "su=00:sg=00:ca=00:ow=00:st=00:tw=00:ex=00:")
+	append_path("LS_COLORS", "su=00:sg=00:ca=00:ow=00:st=00:tw=00:ex=00:or=00:")
 end
 
 --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This avoids issues for ls in $HOME with symbolic links when scratch
is down.

By default symbolic links that point to an invalid location are
red on black, and valid ones are cyan.

This change makes the invalid ones cyan too, and avoids multiple
syscalls for plain "ls --color=auto".