### PR TITLE
Easier debugging

### DIFF
--- a/modules-avx/gentoo/2020.lua
+++ b/modules-avx/gentoo/2020.lua
@@ -20,4 +20,5 @@ if not cuda_driver_version or cuda_driver_version == "" then
 	cuda_driver_version = get_installed_cuda_driver_version()
 end
 
-assert(loadfile("/cvmfs/soft.computecanada.ca/custom/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
+local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+assert(loadfile(custom_root .. "/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)

--- a/modules-avx2/gentoo/2020.lua
+++ b/modules-avx2/gentoo/2020.lua
@@ -20,4 +20,5 @@ if not cuda_driver_version or cuda_driver_version == "" then
 	cuda_driver_version = get_installed_cuda_driver_version()
 end
 
-assert(loadfile("/cvmfs/soft.computecanada.ca/custom/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
+local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+assert(loadfile(custom_root .. "/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)

--- a/modules-avx512/gentoo/2020.lua
+++ b/modules-avx512/gentoo/2020.lua
@@ -20,4 +20,5 @@ if not cuda_driver_version or cuda_driver_version == "" then
 	cuda_driver_version = get_installed_cuda_driver_version()
 end
 
-assert(loadfile("/cvmfs/soft.computecanada.ca/custom/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
+local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+assert(loadfile(custom_root .. "/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)

--- a/modules-sse3/gentoo/2020.lua
+++ b/modules-sse3/gentoo/2020.lua
@@ -20,4 +20,5 @@ if not cuda_driver_version or cuda_driver_version == "" then
 	cuda_driver_version = get_installed_cuda_driver_version()
 end
 
-assert(loadfile("/cvmfs/soft.computecanada.ca/custom/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
+local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+assert(loadfile(custom_root .. "/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)

--- a/modules/arch/avx.lua
+++ b/modules/arch/avx.lua
@@ -1,4 +1,5 @@
 if (mode() ~= "spider") then
-	prepend_path("MODULEPATH","/cvmfs/soft.computecanada.ca/custom/modules-avx")
+	local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+	prepend_path("MODULEPATH", custom_root .. "/modules-avx")
 	setenv("EBVERSIONARCH","avx")
 end

--- a/modules/arch/avx2.lua
+++ b/modules/arch/avx2.lua
@@ -1,4 +1,5 @@
 if (mode() ~= "spider") then
-	prepend_path("MODULEPATH","/cvmfs/soft.computecanada.ca/custom/modules-avx2")
+	local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+	prepend_path("MODULEPATH", custom_root .. "/modules-avx2")
 	setenv("EBVERSIONARCH","avx2")
 end

--- a/modules/arch/avx512.lua
+++ b/modules/arch/avx512.lua
@@ -1,4 +1,5 @@
 if (mode() ~= "spider") then
-	prepend_path("MODULEPATH","/cvmfs/soft.computecanada.ca/custom/modules-avx512")
+	local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+	prepend_path("MODULEPATH", custom_root .. "/modules-avx512")
 	setenv("EBVERSIONARCH","avx512")
 end

--- a/modules/arch/sse3.lua
+++ b/modules/arch/sse3.lua
@@ -1,4 +1,5 @@
 if (mode() ~= "spider") then
-	prepend_path("MODULEPATH","/cvmfs/soft.computecanada.ca/custom/modules-sse3")
+	local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+	prepend_path("MODULEPATH", custom_root .. "/modules-sse3")
 	setenv("EBVERSIONARCH","sse3")
 end

--- a/modules/gentoo/2020.lua
+++ b/modules/gentoo/2020.lua
@@ -27,6 +27,7 @@ if not cuda_driver_version or cuda_driver_version == "" then
 	cuda_driver_version = get_installed_cuda_driver_version()
 end
 
-assert(loadfile("/cvmfs/soft.computecanada.ca/custom/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
+local custom_root = os.getenv("RSNT_CUSTOM_ROOT") or "/cvmfs/soft.computecanada.ca/custom"
+assert(loadfile(custom_root .. "/modules/gentoo/2020.lua.core"))(arch, cpu_vendor_id, interconnect, cuda_driver_version)
 conflict("StdEnv/2016.4")
 conflict("StdEnv/2018.3")


### PR DESCRIPTION
This PR is only meant to allow for easier debugging and testing in one's account by allowing to redirect the root folder of our core modules to a path different than `/cvmfs/soft.computecanada.ca/custom` if an environment variable is set. 