### PR TITLE
bump Lmod to 8.7.4 to support dynamic modulepaths in caches

### DIFF
--- a/bin/computecanada/diskusage_report
+++ b/bin/computecanada/diskusage_report
@@ -55,6 +55,10 @@ REPORT_USER_QUOTA_ON_PROJECT=0
 if [[ "$CC_CLUSTER" == "cedar" || "$CC_CLUSTER" == "graham" || "$CC_CLUSTER" == "beluga" || "$CC_CLUSTER" == "siku" ]]; then
 	REPORT_USER_QUOTA_ON_PROJECT=1
 fi
+REPORT_NEARLINE_QUOTA=0
+if [[ "$CC_CLUSTER" == "narval" ]]; then
+	REPORT_NEARLINE_QUOTA=1
+fi
 QUOTA_IN_FILES=0
 if [[ "$CC_CLUSTER" == "siku" ]]; then
 	QUOTA_IN_FILES=1
@@ -272,6 +276,11 @@ if [[ "$ARG_ALL" == 1 || "$ARG_PROJECT" == 1 ]]; then
 fi
 if [[ "$ARG_ALL" == 1 || "$ARG_NEARLINE" == 1 ]]; then
 	if [[ -d "/nearline" ]]; then
+		if [[ "$REPORT_NEARLINE_QUOTA" == 1 ]]; then
+	                for p in $(get_projects "nearline"); do
+	                        find_and_report_usage $p /nearline
+	                done
+		fi
 		for p in $(get_projects "nearline"); do
 			fs="nearline"
 			db="/${fs}/.duc_databases/${p}.sqlite"

--- a/sources/install-lmod.sh
+++ b/sources/install-lmod.sh
@@ -4,8 +4,8 @@ cd /tmp/build-lmod
 CUSTOM=/cvmfs/soft.computecanada.ca/custom
 LUA=/cvmfs/soft.computecanada.ca/custom/software/lua
 TCL=/cvmfs/soft.computecanada.ca/custom/software/tcl
-tar xf $CUSTOM/sources/Lmod-8.6.16.tar.gz
-cd Lmod-8.6.16
+tar xf $CUSTOM/sources/Lmod-8.7.4.tar.gz
+cd Lmod-8.7.4
 export CPATH=$TCL/include
 export LIBRARY_PATH=$TCL/lib
 export PATH=$TCL/bin:$LUA/bin:$PATH


### PR DESCRIPTION
This should be one more step toward fixing 
https://github.com/ComputeCanada/software-stack/issues/110

Once tested a bit more widely, Robert will released Lmod 8.8 to address that. 

Note that this should not be deployed to production without proper testing on Niagara. 