### PR TITLE
No manylinux! Point final!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 anaconda
-python
+python/envs
+python/wheelhouse
 software
-*.pyc
+*.py[co]
 reframe
 *.tar.*
 clusterstats
 bin/computecanada/clusterstats
+__pycache__

--- a/python/site-packages/_manylinux.py
+++ b/python/site-packages/_manylinux.py
@@ -1,4 +1,7 @@
 manylinux1_compatible = False
 manylinux2010_compatible = False
 manylinux2014_compatible = False
-manylinux_2_24_compatible = False
+
+# Ignore any manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_${ARCH}
+def manylinux_compatible(*_, **__):  # PEP 600
+    return False

--- a/python/site-packages/_manylinux.py
+++ b/python/site-packages/_manylinux.py
@@ -1,0 +1,4 @@
+manylinux1_compatible = False
+manylinux2010_compatible = False
+manylinux2014_compatible = False
+manylinux_2_24_compatible = False


### PR DESCRIPTION
Ignore any `manylinux_x_y` wheels! 

With PEP600 (https://peps.python.org/pep-0600/) there simply too many
combinations. The `manylinux_compatible` function takes care to discard
any manylinux_x_y candidate.

Previous version of pip refused to install manylinux wheels but this solve an issue where a recent pip (22.2) would still install a
manylinux_x_y wheel.

With our system `_manylinux.py`, it had precedence over the `no-manylinux` package, hence one could still install such packages:
```bash
(16879) ~ $ pip install no-manylinux
Successfully installed no-manylinux-3.0.0
(16879) ~ $ pip install orjson-3.7.8-cp38-cp38-manylinux_2_28_x86_64.whl 
Successfully installed orjson-3.7.8
```

With this fix:
```bash
(1260) ~ $ pip install orjson-3.7.8-cp38-cp38-manylinux_2_28_x86_64.whl 
ERROR: orjson-3.7.8-cp38-cp38-manylinux_2_28_x86_64.whl is not a supported wheel on this platform.
```