### PR TITLE
Singularity/Apptainer: add custom bin directory to PATH

### DIFF
--- a/modules/apptainer/1.0.lua
+++ b/modules/apptainer/1.0.lua
@@ -13,6 +13,8 @@ version differences between the source and target systems.
 
 local root = "/opt/software/apptainer-1.0"
 
+-- for symlinked /usr/sbin/unsquashfs
+prepend_path("PATH", "/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin")
 prepend_path("PATH", pathJoin(root, "bin"))
 local slurm_tmpdir = os.getenv("SLURM_TMPDIR") or nil
 local scratch = os.getenv("SCRATCH") or "/tmp"

--- a/modules/singularity/3.7.lua
+++ b/modules/singularity/3.7.lua
@@ -13,6 +13,8 @@ version differences between the source and target systems.
 
 local root = "/opt/software/singularity-3.7"
 
+-- for symlinked unsquashfs
+prepend_path("PATH", "/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin")
 prepend_path("PATH", pathJoin(root, "bin"))
 local slurm_tmpdir = os.getenv("SLURM_TMPDIR") or nil
 local scratch = os.getenv("SCRATCH") or "/tmp"

--- a/modules/singularity/3.8.lua
+++ b/modules/singularity/3.8.lua
@@ -13,6 +13,8 @@ version differences between the source and target systems.
 
 local root = "/opt/software/singularity-3.8"
 
+-- for symlinked unsquashfs
+prepend_path("PATH", "/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin")
 prepend_path("PATH", pathJoin(root, "bin"))
 local slurm_tmpdir = os.getenv("SLURM_TMPDIR") or nil
 local scratch = os.getenv("SCRATCH") or "/tmp"


### PR DESCRIPTION
The unsquashfs binary in Gentoo is incompatible with Apptainer < 1.1 and Singularity 3.7/3.8. Force the use of /usr/sbin/unsquashfs via a symbolic link in
/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin and adding that to PATH.

This didn't use to be necessary since Singularity/Apptainer rejected the Gentoo unsquashfs because it did not support xattr. Now that it does support xattr (for compatibility with 1.1) it runs into a GLIBC_PRIVATE symbol issue with older versions on CentOS 7.