### PR TITLE
Du explorer/fix parent dir

### DIFF
--- a/bin/computecanada/diskusage_explorer
+++ b/bin/computecanada/diskusage_explorer
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-this_bin=$(basename $0)
+this_bin=$(basename "$0")
 
 echo_fr_or_else() {
   if [[ "$LANG" =~ ^fr_ ]]; then echo "$1"; else echo "$2"; fi
@@ -38,8 +38,8 @@ if [ ! -d "$path" ]; then
 fi
 
 # Get the full path without /lustre0*
-path=$(realpath $path | sed -e "s_^/lustre[0-9]\{2\}__g")
-fs=$(echo $path | awk -F "/" '{print $2}')
+path=$(realpath "$path" | sed -e "s_^/lustre[0-9]\{2\}__g")
+fs=$(echo "$path" | awk -F "/" '{print $2}')
 
 # If the file system is /nearline, abort
 if [ "$fs" = "nearline" ]; then
@@ -51,15 +51,15 @@ fi
 
 # If the path is in the project space
 if [[ "$path" =~ ^/project/[[:digit:]]* ]]; then
-  gid=$(echo $path | awk -F "/" '{print $3}')
+  gid=$(echo "$path" | awk -F "/" '{print $3}')
   gname=$(id | cut -d' ' -f3 | cut -d= -f2 | tr , '\n' | \
     grep $gid | cut -d'(' -f2 | cut -d')' -f1)
 
   duc_db="/project/.duc_databases/${gname}.sqlite"
-  query_path=$(echo $path | sed -e "s_^/project/${gid}_/project/${gname}_g")
+  query_path=$(echo "$path" | sed -e "s_^/project/${gid}_/project/${gname}_g")
 else
   duc_db="/${fs}/.duc_databases/${USER}.sqlite"
-  query_path=$path
+  query_path="$path"
 fi
 
 if [ "$2" = "--batch" ]; then

--- a/bin/computecanada/diskusage_explorer
+++ b/bin/computecanada/diskusage_explorer
@@ -1,18 +1,33 @@
 #!/bin/bash
 
+this_bin=$(basename $0)
+
 echo_fr_or_else() {
   if [[ "$LANG" =~ ^fr_ ]]; then echo "$1"; else echo "$2"; fi
 }
 
-
-if [[ "$#" -lt 1 ]]; then
+print_usage() {
   echo_fr_or_else "Syntaxe:" "Usage:"
   echo_fr_or_else \
-    "$0 répertoire_parent_dans_espace_projet [--batch [options]]" \
-    "$0 parent_directory_in_project_space [--batch [options]]"
-  exit 1
-fi
+    "$this_bin [-h|--help] répertoire_parent [--batch ['<options>']]" \
+    "$this_bin [-h|--help] parent_directory [--batch ['<options>']]"
 
+  if [[ "$1" = "help" ]]; then
+    echo -e "\nArguments:"
+    echo_fr_or_else \
+      "  --batch      # Mode non-interactif - affiche le résultat et quitte" \
+      "  --batch      # Batch mode - prints the result and quits"
+    echo_fr_or_else \
+      "  '<options>'  # Voir les options de duc avec : duc ls --help" \
+      "  '<options>'  # See the duc options with: duc ls --help"
+  fi
+}
+
+# Check input arguments
+if [[ "$#" -lt 1 ]]; then print_usage; exit 1; fi
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then print_usage help; exit 0; fi
+
+# Check if the path exists and is a directory
 path="$1"
 
 if [ ! -d "$path" ]; then
@@ -22,23 +37,33 @@ if [ ! -d "$path" ]; then
   exit 1
 fi
 
-path=$(realpath $path)
+# Get the full path without /lustre0*
+path=$(realpath $path | sed -e "s_^/lustre[0-9]\{2\}__g")
+fs=$(echo $path | awk -F "/" '{print $2}')
 
-if [[ ! "$path" =~ ^/lustre[[:digit:]]{2}/project/[[:digit:]]*/ ]]; then
+# If the file system is /nearline, abort
+if [ "$fs" = "nearline" ]; then
   echo_fr_or_else \
-    "Erreur: le chemin '$path' n'est pas dans un espace projet." \
-    "Error: full path '$path' is not in a project space."
-  exit 1
+    "Erreur: l'information n'est pas disponible pour l'espace Nearline." \
+    "Error: the information is not available for the Nearline space."
+  exit 2
 fi
 
-gid=$(echo $path | awk -F "/" '{print $4}')
-gname=$(id | cut -d' ' -f3 | cut -d= -f2 | tr , '\n' | grep $gid | cut -d'(' -f2 | cut -d')' -f1)
+# If the path is in the project space
+if [[ "$path" =~ ^/project/[[:digit:]]* ]]; then
+  gid=$(echo $path | awk -F "/" '{print $3}')
+  gname=$(id | cut -d' ' -f3 | cut -d= -f2 | tr , '\n' | \
+    grep $gid | cut -d'(' -f2 | cut -d')' -f1)
 
-duc_db="/project/.duc_databases/${gname}.sqlite"
-query_path=$(echo $path | sed -e "s_^/lustre[0-9]\{2\}__g;s_/$gid/_/$gname/_g")
+  duc_db="/project/.duc_databases/${gname}.sqlite"
+  query_path=$(echo $path | sed -e "s_^/project/${gid}_/project/${gname}_g")
+else
+  duc_db="/${fs}/.duc_databases/${USER}.sqlite"
+  query_path=$path
+fi
 
 if [ "$2" = "--batch" ]; then
-  duc ls $3 --database=${duc_db} $query_path
+  duc ls $3 --database="$duc_db" "$query_path"
 else
-  duc ui --database=${duc_db} $query_path
+  duc ui --database="$duc_db" "$query_path"
 fi


### PR DESCRIPTION
La précédente version était basée sur les exemples qui n'utilisaient que `/project`. Et encore, les exemples de la documentation ne fonctionnaient pas à cause de l'expression régulière qui exigeait un `/` après le GID... Bref, voilà une nouvelle version : 
* Nouveaux arguments `-h` et `--help` avec plus d'information
* Compatible avec les chemins dans `/home` et `/scratch`, en plus de `/project/<gid>`
* Compatible avec des paths contenant des espaces