### PR TITLE
Bringing back support for /nearline

### DIFF
--- a/bin/computecanada/diskusage_explorer
+++ b/bin/computecanada/diskusage_explorer
@@ -41,22 +41,14 @@ fi
 path=$(realpath "$path" | sed -e "s_^/lustre[0-9]\{2\}__g")
 fs=$(echo "$path" | awk -F "/" '{print $2}')
 
-# If the file system is /nearline, abort
-if [ "$fs" = "nearline" ]; then
-  echo_fr_or_else \
-    "Erreur: l'information n'est pas disponible pour l'espace Nearline." \
-    "Error: the information is not available for the Nearline space."
-  exit 2
-fi
-
-# If the path is in the project space
-if [[ "$path" =~ ^/project/[[:digit:]]* ]]; then
+# If the path is in the project or nearline space
+if [[ "$path" =~ ^/(project|nearline)/[[:digit:]]* ]]; then
   gid=$(echo "$path" | awk -F "/" '{print $3}')
   gname=$(id | cut -d' ' -f3 | cut -d= -f2 | tr , '\n' | \
     grep $gid | cut -d'(' -f2 | cut -d')' -f1)
 
-  duc_db="/project/.duc_databases/${gname}.sqlite"
-  query_path=$(echo "$path" | sed -e "s_^/project/${gid}_/project/${gname}_g")
+  duc_db="/${fs}/.duc_databases/${gname}.sqlite"
+  query_path=$(echo "$path" | sed -e "s_^/${fs}/${gid}_/${fs}/${gname}_g")
 else
   duc_db="/${fs}/.duc_databases/${USER}.sqlite"
   query_path="$path"


### PR DESCRIPTION
Bien que la [page de documentation](https://docs.alliancecan.ca/wiki/Diskusage_Explorer) ne le mentionnait pas, la sortie de `diskusage_report` mentionne la possibilité d'appeler le script avec un chemin vers `/nearline`. Les fichiers SQLite étaient effectivement présents sur Béluga. Un correctif a été implémenté pour que ce soit aussi le cas sur Narval. Ainsi, `diskusage_explorer` devrait pouvoir fonctionner avec des chemins dans `/nearline` et cette version permet de le faire.