### PR TITLE
Use x86-64-v{3,4} in path names.

### DIFF
--- a/modules/gentoo/2023.lua.core
+++ b/modules/gentoo/2023.lua.core
@@ -72,11 +72,18 @@ setenv("EPREFIX", root)
 setenv("EBROOTGENTOO", pathJoin(root, "/usr"))
 setenv("EBVERSIONGENTOO", "2023")
 
+local subdir = "easybuild/modules/2023"
+if arch == "avx512" then
+	subdir = pathJoin(subdir, "x86-64-v4")
+else
+	subdir = pathJoin(subdir, "x86-64-v3")
+end
+
 if (mode() ~= "spider") then
-	prepend_path("MODULEPATH", "/cvmfs/soft.computecanada.ca/easybuild/modules/2023/Core")
-	prepend_path("MODULEPATH", pathJoin("/cvmfs/soft.computecanada.ca/easybuild/modules/2023", arch, "Core"))
+	prepend_path("MODULEPATH", pathJoin("/cvmfs/soft.computecanada.ca", subdir, "Core"))
+	prepend_path("MODULEPATH", pathJoin("/cvmfs/soft.computecanada.ca", subdir, "Compiler/gcccore"))
 	if user ~= "ebuser" then
-		prepend_path("MODULEPATH", pathJoin(home, ".local/easybuild/modules/2023/Core"))
-		prepend_path("MODULEPATH", pathJoin(home, ".local/easybuild/modules/2023", arch, "Core"))
+		prepend_path("MODULEPATH", pathJoin(home, ".local", subdir, "Core"))
+		prepend_path("MODULEPATH", pathJoin(home, ".local", subdir, "Compiler/gcccore"))
 	end
 end


### PR DESCRIPTION
This uses
`/cvmfs/soft.computecanada.ca/easybuild/modules/2023/x86-64-v3/Compiler/gcccore:/cvmfs/soft.computecanada.ca/easybuild/modules/2023/x86-64-v3/Core`
 instead of
`/cvmfs/soft.computecanada.ca/easybuild/modules/2023/avx2/Core:/cvmfs/soft.computecanada.ca/easybuild/modules/2023/Core` 
in `MODULEPATH` for `avx2` and `v4` for `avx512`; the `Core` for v4 will be a symlink to `v3`.

This makes the path consistent with `EBROOTGENTOO`
(`/cvmfs/soft.computecanada/gentoo/2023/x86-64-v3/usr`) but keeps `avx2` and `avx512` names user facing for backwards compatibility.