### PR TITLE
Set 2020 as default for gentoo.

### DIFF
--- a/modules/gentoo/.modulerc.lua
+++ b/modules/gentoo/.modulerc.lua
@@ -1,0 +1,1 @@
+module_version("gentoo/2020", "default")


### PR DESCRIPTION
So if anyone does "module load gentoo" they won't be surprised when 2023 is published.