### PR TITLE
add custom MODULERCFILE when loading the old StdEnv

### DIFF
--- a/modules/StdEnv/2016.4.lua
+++ b/modules/StdEnv/2016.4.lua
@@ -12,3 +12,4 @@ else
 	load("intel/2016.4")
 end
 load("openmpi/2.1.1")
+append_path("MODULERCFILE", "/cvmfs/soft.computecanada.ca/config/lmod/modulerc_2016_2018") 

--- a/modules/StdEnv/2018.3.lua
+++ b/modules/StdEnv/2018.3.lua
@@ -12,3 +12,4 @@ else
 	load("intel/2018.3")
 end
 load("openmpi/3.1.2")
+append_path("MODULERCFILE", "/cvmfs/soft.computecanada.ca/config/lmod/modulerc_2016_2018") 


### PR DESCRIPTION
This works with https://github.com/ComputeCanada/software-stack-config/pull/61

The only caveat is that the new MODULERCFILE does not apply until the module is loaded. That means if a user is loading StdEnv/2016.4 or StdEnv/2018.3 and is relying on the default versions, they may get more recent versions. 