### PR TITLE
Switch cmake wrapper for 2023 to module for 3.27.7 instead of Gentoo

### DIFF
--- a/bin/cmake
+++ b/bin/cmake
@@ -5,6 +5,6 @@ if [ -n "$NIXUSER_PROFILE" ]; then
 elif [ "$EBVERSIONGENTOO" = "2020" ]; then
 	CMAKEDIR=/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/cmake/3.23.1/bin
 elif [ "$EBVERSIONGENTOO" = "2023" ]; then
-	CMAKEDIR=$EBROOTGENTOO/bin
+	CMAKEDIR=/cvmfs/soft.computecanada.ca/easybuild/software/2023/x86-64-v3/Core/cmake/3.27.7/bin
 fi
 exec $CMAKEDIR/$(basename "$0") ${1+"$@"}


### PR DESCRIPTION
The lack of cmake3 in Gentoo confuses this logic. I could instead point it to the Gentoo cmake command, but this is simpler.