### PR TITLE
Add .modulerc.lua for singularity/3.8 default

### DIFF
--- a/modules/singularity/.modulerc.lua
+++ b/modules/singularity/.modulerc.lua
@@ -1,0 +1,1 @@
+module_version("singularity/3.8", "default")


### PR DESCRIPTION
Since both 3.7 and 3.8 are hidden, "module load singularity" didn't work. It's nicer if it works with the usual warning so users know about apptainer.