### PR TITLE
Port use of APPTAINER_* environment variables to apptainer-suid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 anaconda
 python/envs
 python/wheelhouse
-software
+software/2020
+software/centos6.sif
+software/librt-compat
+software/lmod
+software/lua
+software/tcl
 *.py[co]
 reframe
 *.tar.*

--- a/modules/apptainer-suid/1.1.lua
+++ b/modules/apptainer-suid/1.1.lua
@@ -13,14 +13,9 @@ version differences between the source and target systems.
 
 local root = "/opt/software/apptainer-1.1"
 
--- for symlinked /usr/sbin/unsquashfs
-prepend_path("PATH", "/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin")
 prepend_path("PATH", pathJoin(root, "bin"))
-local slurm_tmpdir = os.getenv("SLURM_TMPDIR") or nil
-local scratch = os.getenv("SCRATCH") or "/tmp"
-if slurm_tmpdir then
-	setenv("APPTAINER_TMPDIR",slurm_tmpdir)
-else
-	setenv("APPTAINER_TMPDIR",scratch)
-end
-
+-- for symlinked /usr/sbin/unsquashfs and apptainer wrapper
+prepend_path("PATH", "/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin")
+setenv("EBROOTAPPTAINER", root)
+setenv("EBVERSIONAPPTAINER", "1.1")
+assert(loadfile("/cvmfs/soft.computecanada.ca/config/lmod/apptainer_custom.lua"))()

--- a/software/apptainer/bin/apptainer
+++ b/software/apptainer/bin/apptainer
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [[ -z "$APPTAINER_TMPDIR" ]]; then
+        export APPTAINER_TMPDIR="/var/tmp"
+        if [[ -d "/localscratch" && -w "/localscratch" ]]; then
+                export APPTAINER_TMPDIR="/localscratch"
+        fi
+fi
+exec $EBROOTAPPTAINER/bin/apptainer ${1+"$@"}

--- a/software/apptainer/bin/singularity
+++ b/software/apptainer/bin/singularity
@@ -1,0 +1,1 @@
+apptainer

--- a/software/apptainer/bin/unsquashfs
+++ b/software/apptainer/bin/unsquashfs
@@ -1,0 +1,1 @@
+/usr/sbin/unsquashfs


### PR DESCRIPTION
This uses the existing structure of
`/cvmfs/soft.computecanada.ca/custom/software/apptainer/bin` to create a wrapper file there and adjusts the module to the same thing for environment variables as plain apptainer