### PR TITLE
do not add nixpkgs based paths to MODULEPATH when using spider, regardless of CPU type

### DIFF
--- a/modules/nixpkgs/16.09.lua.core
+++ b/modules/nixpkgs/16.09.lua.core
@@ -93,8 +93,8 @@ setenv("EASYBUILD_BUILDPATH", pathJoin("/tmp", os.getenv("USER")))
 setenv("EBROOTNIXPKGS", root)
 setenv("EBVERSIONNIXPKGS", "16.09")
 
--- do not modify the module path for amd in spider mode, so users don't find it
-if cpu_vendor_id ~= "amd" or (cpu_vendor_id == "amd" and (mode() == "load" or mode() == "unload")) then
+-- only add to MODULEPATH in load/unload mode so that spider does not find it
+if mode() == "load" or mode() == "unload" then
 	if generic_nixpkgs then
 		prepend_path("MODULEPATH", "/cvmfs/soft.computecanada.ca/easybuild/modules/2017/Core")
 	else


### PR DESCRIPTION
I believe this fixes https://github.com/ComputeCanada/software-stack/issues/152 and possibly also https://github.com/ComputeCanada/software-stack/issues/153 as well