### PR TITLE
Refuse to load StdEnv/2023 and gentoo/2023 for sse3/avx

### DIFF
--- a/modules/StdEnv/2023.lua
+++ b/modules/StdEnv/2023.lua
@@ -4,14 +4,16 @@ require("os")
 load("CCconfig")
 load("gentoo/2023")
 
-if (mode() == "spider") then
-	-- set by gentoo/2023 module
-	local arch = os.getenv("RSNT_ARCH")
-	if arch == "avx512" then
-		newarch = "x86-64-v4"
-	else
-		newarch = "x86-64-v3"
-	end
+-- set by gentoo/2023 module
+local arch = os.getenv("RSNT_ARCH")
+if arch == "avx2" then
+	newarch = "x86-64-v3"
+elseif arch == "avx512" then
+	newarch = "x86-64-v4"
+end
+-- gentoo/2023 will not load for sse3 and avx
+
+if (mode() == "spider" and (arch == "avx2" or arch == "avx512")) then
 	local coresubdir = "easybuild/modules/2023/x86-64-v3"
 	local subdir = pathJoin("easybuild/modules/2023", newarch)
 	prepend_path("MODULEPATH", pathJoin("/cvmfs/soft.computecanada.ca", coresubdir, "Core"))

--- a/modules/gentoo/2023.lua
+++ b/modules/gentoo/2023.lua
@@ -15,9 +15,9 @@ end
 if arch ~= "avx2" and arch ~= "avx512" then
 	local lang = os.getenv("LANG") or "en"
 	if string.sub(lang,1,2) == "fr" then
-		LmodError("RSNT_ARCH=sse3 et RSNT_ARCH=avx ne sont plus soutenus dans StdEnv/2023.")
+		LmodError("L'environnement StdEnv/2023 n'est pas disponible pour l'architecture " .. arch .. ".")
 	else
-		LmodError("RSNT_ARCH=sse3 and RSNT_ARCH=avx are no longer supported in StdEnv/2023.")
+		LmodError("The StdEnv/2023 environment is not available for architecture " .. arch .. ".")
 	end
 end
 if not cpu_vendor_id or cpu_vendor_id == "" then

--- a/modules/gentoo/2023.lua
+++ b/modules/gentoo/2023.lua
@@ -12,6 +12,14 @@ if not arch or arch == "" then
 		arch = get_highest_supported_architecture()
 	end
 end
+if arch ~= "avx2" and arch ~= "avx512" then
+	local lang = os.getenv("LANG") or "en"
+	if string.sub(lang,1,2) == "fr" then
+		LmodError("RSNT_ARCH=sse3 et RSNT_ARCH=avx ne sont plus soutenus dans StdEnv/2023.")
+	else
+		LmodError("RSNT_ARCH=sse3 and RSNT_ARCH=avx are no longer supported in StdEnv/2023.")
+	end
+end
 if not cpu_vendor_id or cpu_vendor_id == "" then
 	cpu_vendor_id = get_cpu_vendor_id()
 end


### PR DESCRIPTION
And spider will no longer expand modulepath for them. Tested with `module --force purge` and setting MODULEPATH to the git checkout directory.