### PR TITLE
Fix FPATH handling with newer Lmod

### DIFF
--- a/modules/gentoo/2023.lua.core
+++ b/modules/gentoo/2023.lua.core
@@ -36,6 +36,8 @@ if os.getenv("XDG_CONFIG_DIRS") then
 else
 	setenv("XDG_CONFIG_DIRS", pathJoin(root, "etc/xdg") .. ":/etc/xdg")
 end
+local fpath = capture("unset FPATH; " .. pathJoin(root, "usr/bin/zsh -f -c 'echo $FPATH'")):gsub("\n$","")
+prepend_path("FPATH", fpath)
 
 require("os")
 -- Define RSNT variables


### PR DESCRIPTION
To get zsh working properly we must mimic what Lmod's bash init script does for FPATH in a module (since when the init script runs our Gentoo prefix zsh isn't available yet).

The corresponding Lmod logic is here:
https://github.com/TACC/Lmod/blob/c7974de5ba3376c7bdc123c42a8e9c3648a84ec4/init/bash.in#L30