### PR TITLE
Draft: Get project quota for tamIA's /home and /scratch

### DIFF
--- a/bin/computecanada/diskusage_report
+++ b/bin/computecanada/diskusage_report
@@ -68,6 +68,7 @@ fi
 SCALE="scale"
 SYMLINK_PATH_PROJECTS="projects"
 if [[ "$CC_CLUSTER" == "tamia" ]]; then
+	PID_OFFSET_SCRATCH=20000000
 	SCALE="scale_binary"
 	SYMLINK_PATH_PROJECTS="links"
 fi
@@ -252,7 +253,17 @@ function find_and_report_usage {
 				data=($(get_lustre_project_info $pid $fs))
 			elif [[ "$fs" == "/home" || "$fs" == "/scratch" ]]; then
 				quota_type="user"
-				data=($(get_lustre_user_info $who $fs))
+				if [[ "$CC_CLUSTER" == "tamia" ]]; then
+					uid=$(id -u $who)
+					if [[ "$fs" == "/home" ]]; then
+						pid=$uid
+					elif [[ "$fs" == "/scratch" ]]; then
+						pid=$((uid+PID_OFFSET_SCRATCH))
+					fi
+					data=($(get_lustre_project_info $pid $fs))
+				else
+					data=($(get_lustre_user_info $who $fs))
+				fi
 			else
 				quota_type="group"
 				data=($(get_lustre_group_info $who $fs))


### PR DESCRIPTION
The home and scratch file systems of the tamIA cluster are in the same Lustre namespace. Quota are managed with project quota for Lustre.

The project id for a user home directory is the user's UID while the project id for a user scratch directory is the user's UID plus an offset of 20000000.

This is a draft to discuss how we could implement this change properly. Right now it works on the tamIA cluster, but I do agree the patch is ugly. Note that this change "lies" to the user by stating the quota_type is "user" while it's a project quota, but this is a technicality that should be hidden from end users imho. This is to print `/home (user <username>)` in the description instead of `/home (project <username>)`.