### PR TITLE
gpfs for diskusage_report.py

### DIFF
--- a/bin/computecanada/diskusage_report.py
+++ b/bin/computecanada/diskusage_report.py
@@ -20,9 +20,9 @@ DEFAULT_CONFIG = {
         '/nearline': {'quota_type': 'group'},
     },
     'symlink_paths': ['scratch', ('projects', '*'), ('nearline', '*'), ('links', '*'), ('links/projects', '*'), ('links/nearline', '*')],
+    'gpfs_diskusage_location': None,
 }
 cfg = DEFAULT_CONFIG
-GPFS_DISKUSAGE_LOCATION=os.path.join("/opt/software/diskusage/", os.environ.get("CC_CLUSTER"))
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--home", default=False, action='store_true', help="Display information for the home filesystem")
@@ -145,7 +145,7 @@ def get_quota(path_info, quota_type, quota_identity=None):
         elif quota_type == 'group':
             qt = 'g'
             qtype = 'GRP'
-        fn = os.path.join(GPFS_DISKUSAGE_LOCATION, qt, filesystem.removeprefix('/'), identity)
+        fn = os.path.join(cfg['gpfs_diskusage_location'], qt, filesystem.removeprefix('/'), identity)
         with open(fn, 'r') as quota_file:
             line = quota_file.readlines()[-1]
             tokens = line.split()

--- a/bin/computecanada/diskusage_report.py
+++ b/bin/computecanada/diskusage_report.py
@@ -147,7 +147,7 @@ def get_quota(path_info, quota_type, quota_identity=None):
         # YYYY-mm-dd_HH:MM  Name  fileset  type  KB  quota  limit  in_doubt  grace  |  files  quota  limit  in_doubt  grace
         # Since a column with "fileset" may or may not be present and "grace" may contain a space (e.g. "2 days") we need to 
         # find the index of USR or GRP (type column) or the '|' that separates Block Limits from File Limits.
-        data = [tokens[tokens.index(qtype)+1], tokens[tokens.index(qtype)+1], tokens[tokens.index('|')+1], tokens[tokens.index('|')+2]]
+        data = [tokens[tokens.index(qtype)+1], tokens[tokens.index(qtype)+2], tokens[tokens.index('|')+1], tokens[tokens.index('|')+2]]
 
     if isinstance(data, list) and len(data) == 4:
         quota_info = {}

--- a/bin/computecanada/diskusage_report_configs/argo.yaml
+++ b/bin/computecanada/diskusage_report_configs/argo.yaml
@@ -1,0 +1,11 @@
+filesystems:
+  /home:
+    quota_type: user
+  /scratch:
+    quota_type: user
+  /project:
+    quota_type: group
+    extra_quotas:
+      - quota_type: group
+        quota_id: user
+gpfs_diskusage_location: /opt/software/diskusage/argo

--- a/bin/computecanada/diskusage_report_configs/siku.yaml
+++ b/bin/computecanada/diskusage_report_configs/siku.yaml
@@ -1,0 +1,11 @@
+filesystems:
+  /home:
+    quota_type: user
+  /scratch:
+    quota_type: user
+  /project:
+    quota_type: group
+    extra_quotas:
+      - quota_type: group
+        quota_id: user
+gpfs_diskusage_location: /opt/software/diskusage/siku


### PR DESCRIPTION
Tested with Siku and Argo.

The only interesting issue that I'm seeing is that the order in which the various projects are reported are not consistent with the shell version.

```
[stuekero@argologin1.argo:~/project/stuekero/software-stack-custom/bin/computecanada]
$ diskusage_report 
                             Description                Space           # of files
                   /home (user stuekero)            1340M/52G             36k/512k
                /scratch (user stuekero)                0/20T              2/1024k
               /project (group stuekero)          2384k/1048G               6/512k
        /project (group def-stuekero-ab)          5603M/1048G            1522/512k
        /project (group def-stuekero-ac)           416k/1048G               3/512k
--
On some clusters, a break down per user may be available by adding the option '--per_user'.
[stuekero@argologin1.argo:~/project/stuekero/software-stack-custom/bin/computecanada]
$ ./diskusage_report.py 
                             Description                Space           # of files
                   /home (user stuekero)        1341MB/  52GB            36K/ 512K
                /scratch (user stuekero)            0B/  21TB              2/1024K
        /project (group def-stuekero-ab)        5603MB/1049GB           1522/ 512K
               /project (group stuekero)        2384KB/1049GB              6/ 512K
        /project (group def-stuekero-ac)         416KB/1049GB              3/ 512K
--
On some clusters, a break down per user may be available by adding the option '--per_user'.
```

```
[stuekero@sikulogin1.siku:~/project/stuekero/software-stack-custom/bin/computecanada]
$ diskusage_report 
                             Description                Space           # of files
                   /home (user stuekero)              46G/52G            352k/512k
                /scratch (user stuekero)             338G/20T           155k/1024k
               /project (group stuekero)          1624k/4096k                7/200
          /project (group an-obfugroup1)           280k/1048G              12/512k
        /project (group def-stuekero-ab)           239G/1048G            290k/512k
        /project (group def-stuekero-ac)          6333M/1048G             68k/512k
--
On some clusters, a break down per user may be available by adding the option '--per_user'.
[stuekero@sikulogin1.siku:~/project/stuekero/software-stack-custom/bin/computecanada]
$ ./diskusage_report.py 
                             Description                Space           # of files
                   /home (user stuekero)          46GB/  52GB           352K/ 512K
                /scratch (user stuekero)         338GB/  21TB           156K/1024K
        /project (group def-stuekero-ab)         239GB/1049GB           290K/ 512K
               /project (group stuekero)        1624KB/4096KB               7/ 200
        /project (group def-stuekero-ac)        6333MB/1049GB            69K/ 512K
          /project (group an-obfugroup1)         280KB/1049GB             12/ 512K
--
On some clusters, a break down per user may be available by adding the option '--per_user'.
```