### PR TITLE
Only test if the interpreter is from CVMFS

### DIFF
--- a/bin/run_mcr_binary.sh
+++ b/bin/run_mcr_binary.sh
@@ -10,7 +10,7 @@ if [ "x$1" = "x" ]; then
 else
 	exe=$1
 	shift 1
-	if [[ $(patchelf --print-interpreter $exe) != "/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/lib/ld-linux-x86-64.so.2" ]]; then
+	if [[ $(patchelf --print-interpreter $exe) != *"/cvmfs/soft.computecanada.ca/"* ]]; then
 		echo "------------------------------------------"
 		echo "This binary was not compiled on this plateform. Please run the command \"setrpaths.sh --path $exe\" to make it compatible with this plateform."
 		echo "Cet exécutable n'a pas été compilé sur cette plateforme. Veuillez exécuter la commande \"setrpaths.sh --path $exe\" pour le rendre compatible avec cette plateform."


### PR DESCRIPTION
To make this wrapper script compatible with modules outside of the Nix collection, it only needs to test if the interpreter is in `/cvmfs/soft.computecanada.ca/*`.

The syntax of `*"string"*` is a simple pattern to be matched, where the `string` has to be anywhere in the other string before the `!=` operator.

- https://stackoverflow.com/questions/229551/how-to-check-if-a-string-contains-a-substring-in-bash