### PR TITLE
Fixed shebang and added rorqual case.

### DIFF
--- a/bin/computecanada/partition-stats
+++ b/bin/computecanada/partition-stats
@@ -1,4 +1,4 @@
-#!/cvmfs/soft.computecanada.ca/nix/var/nix/profiles/ruby-2.3.1/bin/ruby
+#!/bin/env ruby
 #----------------------------------------------------------------------------------------#
 ### Name: idle_nodes                                                                     #
 ### Version: 1.1                                                                         #
@@ -130,7 +130,7 @@ when ENV["CC_CLUSTER"] == "beluga" then
 	     name_part  = ["cpubase_bycore_b","cpularge_bycore_b","gpubase_bygpu_b" ]
 	     name_node  = ["cpubase_bynode_b","cpularge_bynode_b","gpubase_bynode_b"]
              name_label = ["Regular   "      ,"Large Mem "       ,"GPU       "      ]
-when ENV["CC_CLUSTER"] == "narval" then
+when ENV["CC_CLUSTER"] == "narval" || ENV["CC_CLUSTER"] == "rorqual" then
              name_part  = ["cpubase_bycore_b","cpularge_bycore_b","gpubase_bygpu_b" ]
              name_node  = ["cpubase_bynode_b","cpularge_bynode_b","gpubase_bynode_b"]
              name_label = ["Regular   "      ,"Large Mem "       ,"GPU       "      ]


### PR DESCRIPTION
Tested on rorqual
```
[coulombc@rorqual3 ~]$ ruby partition-stats.rb

Node type |                     Max walltime                            
          |   3 hr   |  12 hr  |  24 hr  |  72 hr  |  168 hr |  672 hr |
----------|-------------------------------------------------------------
       Number of Queued Jobs by partition Type (by node:by core)        
----------|-------------------------------------------------------------
Regular   |    0:0   |   0:0   |   0:0   |   0:0   |   0:0   |   0:0   |
Large Mem |    0:0   |   0:0   |   0:0   |   0:0   |   0:0   |   0:0   |
GPU       |    1:0   |   0:0   |   0:0   |   0:0   |   0:0   |   0:0   |
----------|-------------------------------------------------------------
      Number of Running Jobs by partition Type (by node:by core)        
----------|-------------------------------------------------------------
Regular   |    0:1   |   0:24  |  15:1   |   1:275 |   0:0   |   0:0   |
Large Mem |    0:0   |   0:0   |   0:0   |   0:0   |   0:0   |   0:0   |
GPU       |    0:0   |   0:40  |   0:9   |   0:0   |   0:0   |   0:0   |
----------|-------------------------------------------------------------
        Number of Idle nodes by partition Type (by node:by core)        
----------|-------------------------------------------------------------
Regular   |   18:18  |  18:18  |  18:18  |  18:18  |  18:18  |   0:0   |
Large Mem |    8:8   |   8:8   |   8:8   |   8:8   |   8:8   |   0:0   |
GPU       |   21:21  |  21:21  |  21:21  |  21:21  |  21:21  |   0:0   |
----------|-------------------------------------------------------------
       Total Number of nodes by partition Type (by node:by core)        
----------|-------------------------------------------------------------
Regular   |  678:678 | 678:678 | 678:678 | 678:678 | 678:678 |   0:0   |
Large Mem |    8:8   |   8:8   |   8:8   |   8:8   |   8:8   |   0:0   |
GPU       |   81:81  |  81:81  |  81:81  |  81:81  |  81:81  |   0:0   |
----------|-------------------------------------------------------------
```