### PR TITLE
StdEnv/2020.lua for newer clusters with H100 GPUs

### DIFF
--- a/modules/StdEnv/2020.lua
+++ b/modules/StdEnv/2020.lua
@@ -4,7 +4,18 @@ require("os")
 load("CCconfig")
 load("gentoo/2020")
 
-if (mode() == "spider") then
+local h100_clusters = {"rorqual", "nibi", "fir", "trillium", "tamia", "killarney", "vulcan"}
+local cluster = os.getenv("CC_CLUSTER")
+local has_h100 = (os.getenv("RSNT_HAS_H100") or "false") == "true"
+for index, value in ipairs(h100_clusters) do
+	if value == cluster then
+		has_h100 = true
+        end
+end
+
+if (has_h100) then
+	pushenv("LMOD_ADMIN_FILE", "/cvmfs/soft.computecanada.ca/config/lmod/admin_2025.list")
+elseif (mode() == "spider") then
 	-- set by gentoo/2020 module
 	local arch = os.getenv("RSNT_ARCH")
 	prepend_path("MODULEPATH", "/cvmfs/soft.computecanada.ca/easybuild/modules/2020/Core")


### PR DESCRIPTION
* Changes LMOD_ADMIN_FILE with new warnings
* Disables spider
* Checks for cluster name or RSNT_HAS_H100