### PR TITLE
Fixed the links/nearlines path for Rorqual

### DIFF
--- a/bin/computecanada/diskusage_report.py
+++ b/bin/computecanada/diskusage_report.py
@@ -19,7 +19,14 @@ DEFAULT_CONFIG = {
         '/project': {'quota_type': 'group'},
         '/nearline': {'quota_type': 'group'},
     },
-    'symlink_paths': ['scratch', ('projects', '*'), ('nearline', '*'), ('links', '*'), ('links/projects', '*'), ('links/nearline', '*')],
+    'symlink_paths': [
+        'scratch',
+        ('projects', '*'),
+        ('nearline', '*'),
+        ('links', '*'),
+        ('links/projects', '*'),
+        ('links/nearlines', '*'),
+    ],
     'gpfs_diskusage_location': None,
 }
 cfg = DEFAULT_CONFIG


### PR DESCRIPTION
On Rorqual, the symlinks to nearline spaces are via `~/links/nearlines` with an `s`.

This change in `diskusage_report.py` is required before we can officially announce that nearline is ready on Rorqual. So, this is relatively urgent (but could wait until Monday morning).